### PR TITLE
Prevent default on accessibility dialog close click

### DIFF
--- a/_includes/sections/rooms.html
+++ b/_includes/sections/rooms.html
@@ -39,7 +39,7 @@
 	</div>
 	<dialog id="accessibility" class="animation-speed-normal animation-ease-in-out fadeIn">
 		<header class="sticky top clearfix requires-js">
-			<a href="{{ page.url }}#" role="button" class="btn btn-transparent float-right" title="close">
+			<a href="{{ page.url }}#" role="button" data-action="back" class="btn btn-transparent float-right" title="close">
 				{% include icon.html icon="x" %}
 			</a>
 		</header>

--- a/js/handlers.js
+++ b/js/handlers.js
@@ -17,3 +17,11 @@ export function hashChange({newURL, oldURL = null})  {
 		leaving.close();
 	}
 }
+
+export function back(event) {
+	if (event instanceof Event) {
+		event.preventDefault();
+	}
+
+	history.back();
+}

--- a/js/index.js
+++ b/js/index.js
@@ -1,7 +1,7 @@
 import 'https://cdn.kernvalley.us/js/std-js/deprefixer.js';
 import 'https://cdn.kernvalley.us/js/std-js/shims.js';
-import { registerServiceWorker, ready } from 'https://cdn.kernvalley.us/js/std-js/functions.js';
-import { hashChange } from './handlers.js';
+import { $, registerServiceWorker, ready } from 'https://cdn.kernvalley.us/js/std-js/functions.js';
+import * as handlers from './handlers.js';
 document.documentElement.classList.replace('no-js', 'js');
 
 if (document.documentElement.dataset.hasOwnProperty('serviceWorker')) {
@@ -11,8 +11,15 @@ if (document.documentElement.dataset.hasOwnProperty('serviceWorker')) {
 ready().then(() => {
 	document.body.classList.toggle('no-dialog', document.createElement('dialog') instanceof HTMLUnknownElement);
 	document.body.classList.toggle('no-details', document.createElement('details') instanceof HTMLUnknownElement);
-	hashChange({newURL: location.href});
+	handlers.hashChange({newURL: location.href});
+	$('[data-action]').click(event => {
+		const action = event.target.closest('[data-action]').dataset.action;
+
+		if (action in handlers) {
+			handlers[action](event);
+		}
+	});
 });
 
 
-window.addEventListener('hashchange', ({newURL, oldURL}) => hashChange({newURL, oldURL}), {passive: true});
+window.addEventListener('hashchange', ({newURL, oldURL}) => handlers.hashChange({newURL, oldURL}), {passive: true});


### PR DESCRIPTION
Instead, use `history.back()` to avoid jumping around page.

Resolves #3 